### PR TITLE
Set valid engines to Node 7.2 and newer

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "description": "Web API Confluence Dashboard",
   "engines": {
-    "node": "7.2.0"
+    "node": ">= 7.2.0"
   },
   "scripts": {
     "coverage": "npm run coverageNode && npm run coverageWeb && istanbul-combine -d .coverage -p summary -r lcov -r html -r json -b . .node_coverage/coverage.json .web_coverage/*/coverage*.json && istanbul check-coverage --config config/istanbul.yml \".coverage/**/coverage*.json\"",


### PR DESCRIPTION
This makes it possible to once again install [browser‑compat‑data](https://github.com/mdn/browser-compat-data) and [browser‑compat‑toolkit](https://github.com/mdn/browser-compat-toolkit) using [yarn](https://yarnpkg.com), without requiring to always pass the `--ignore-engines` flag to every command which affects the installed packages (eg. `yarn install`, `yarn add`, etc…)